### PR TITLE
Adjust draggable attributes on circle and img

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,7 +49,9 @@
     <h2>drag the shapes to their containers.</h2>
     <div>
       <div id="circle-container" class="container">
-        <div id="circle" class="shape"><img width=50 src="circle.png" draggable="true" ondragstart="dragstart_handler(event);"></div>
+        <div id="circle" class="shape" draggable="true" ondragstart="dragstart_handler(event);">
+          <img width=50 src="circle.png" draggable="false">
+        </div>
         <div id="circleDrop" class="dropzone" ondrop="drop_handler(event);" ondragover="dragover_handler(event)" ondragenter="event.preventDefault()"></div>
       </div>
       <div id="square-container" class="container">


### PR DESCRIPTION
Hey @kaganjd - After moving the `draggable="true"` and `ondragstart` handlers from the image to the `div#circle`, it was still broken for me, too.

I wasn't able to figure out what was wrong by reading the MDN docs, so I tried googling for "html5 drag div containing image". The second result was [this StackOverflow answer](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Recommended_Drag_Types#image), which points out that images need to have `draggable="false"`, because they are draggable by default.

So, summarizing: the fix here is to
- set `draggable="true"` on the circle div
- move the `ondragstart` handler to the circle div
- set `draggable="false"` on the circle image

---

Optional: digging into the HTML5 spec

In general, if html or css seems to be doing strange things, it can be helpful to look at the spec to get a definitive answer about how the browser should work. If you take a look at item number one in [this section of the spec](https://html.spec.whatwg.org/multipage/interaction.html#drag-and-drop-processing-model), it explains how the draggable element is chosen:

> ... if the drag operation was invoked on a Document, [the element being dragged] is the first element, going up the ancestor chain, starting at the node that the user tried to drag, that has the IDL attribute `draggable` set to true.

There's also a Note a few lines down that says:

> `img` elements and `a` elements with an `href` attribute have their `draggable` attribute set to true by default.

So, when you drag a div containing an image, the image is the 'node that the user tried to drag', and it has `draggable="true"`, so the image is chosen as the target of the dragstart event (`ev.target`, in your code). The image's default drag behavior handles the dragstart event, so it never bubbles up to the circle div.

By setting `draggable="false"` on the img, the circle div becomes the lowest element in the DOM that's draggable, so the dragstart is fired on it, and the code works.

It's fairly rare to need to consult the spec to understand how something works, and the spec can be very dry reading, but specs are both painfully precise and the basis for all browser implementations, so they can clarify topics left ambiguous elsewhere.

Whew, that was a lot :-) Ping me with any questions